### PR TITLE
Add Generator Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ go install go-micro.dev/v4/cmd/protoc-gen-micro@v4
 
 ## Creating A Service
 
-To create a new service, use the `micro new service` command.
+To create a new service, use the `micro new service` command, and provide either a bare
+service name, or a full GitHub repo module name.
+
+```bash
+$ go-micro new service github.com/<org>/<repo>/helloworld
+...
+```
 
 ```bash
 $ go-micro new service helloworld
@@ -152,13 +158,230 @@ func Greet(ctx context.Context, name string) string {
 }
 ```
 
-### Skaffold
+### gRPC Server/Client
+
+By default, go-micro uses an JSON/HTTP RPC server. Many microservice use
+cases require a gRPC server or client, therefore, go-micro offers a gRPC server 
+built in.
+
+To create a new service with a gRPC server pass the `--grpc` flag to
+the `micro new service` or `micro new function` commands.
+
+```bash
+go-micro new service --grpc helloworld
+```
+
+### Tern - Postgres Migrations
+
+Tern can be used to create and manage postgres migrations. Go-micro can set the
+service up to use Tern SQL migrations.
+
+To create a new service with Tern pass the `--tern` flag to
+the `micro new service` or `micro new function` commands.
+
+To locally run `tern migrate` it is recommended to create a `.env` file with
+connection details as shown below, and manually run `source .env`, as these environment variables
+will also be picked up by pgx.
+
+```env
+PGHOST=localhost
+PGUSER=helloworld
+PGDATABASE=helloworld
+PGPASSWORD=<empty for localhost>
+```
+
+Setting the `--tern` flag in combination with any of the Kubernetes flags will
+also create an `InitContainer` in the deployment manifest to automatically apply
+all migrations upon deployment. You will need to create a `helloworld-postgres-env`
+secret with a `PGPASSWORD` to allow tern to connect to your database instance.
+
+The default database address used is `postgres.database.svc`, and the user and 
+database are set to the service name. To specifiy a different database address
+use the `--postgresaddress="my.namespace.svc"` flag
+
+If you are also using Kustomize to manage your kubernetes resources, be aware
+that you will have to manually add every migration to `resouces/base/kustomization.yaml`.
+And that you will have to pass the `--load-restrictor LoadRestrictionsNone` flag 
+to `kustomize build`, to allow kustomize to access resouces outside of the `base` 
+folder. Tilt and Skaffold will do this for you automatically.
+
+```bash
+go-micro new service --tern helloworld
+```
+
+### sqlc - SQL Code Generation
+
+Sqlc can compile SQL queries into boilerplate Go code that allows you to easily
+create and manage your database layer. Go-micro can set your service up for use
+with sqlc, and used Postgres as a default backend. Sqlc works well in combination 
+with [Tern](#tern---postgres-migrations). 
+
+Place your SQL queries in `postgres/queries/*.sql` and run `make sqlc` to compile.
+Be sure you have your SQL schema defined in `postgres/migrations/*.sql`, as can 
+be done with Tern.
+
+After compilation you can create your database layer in `postgres/*.go` with the
+sqlc connector. An example is provided in `postgres/postgres.go`.
+
+To create a new service with sqlc pass the `--sqlc` flag to
+the `micro new service` or `micro new function` commands.
+
+```bash
+go-micro new service --sqlc helloworld
+```
+
+### Docker BuildKit
+
+[Docker BuildKit](11) is a new container build engine that provides new useful 
+freatures, such as the ability to cache specific directories across builds. This
+can prevent Go from having to re-download modules every build.
+
+To create a new service with the BuildKit engine pass the `--buildkit` flag to
+the `micro new service` or `micro new function` commands.
+
+```bash
+go-micro new service --buildkit helloworld
+```
+
+### Private Git Repository
+
+If you plan on hosting the service in a private Git repository, the docker file
+needs some tweaks to allow Go to access and clone the private repositorie(s).
+
+For this, SSH Git access needs to be set up, and an SSH agent needs to be running,
+with the Git SSH key added. You can manually start an SSH agent and add the SSH key
+by running:
+
+```bash
+$ eval $(ssh-agent) && ssh-add <optional: path to ssh key, default: ~/.shh/id_rsa>
+```
+
+Alternatively, you can use [Tilt](#tilt---kubernets-deployment) to set one up 
+for you.
+
+To create a new service with a private Git repository pass the `--privaterepo` flag to
+the `micro new service` or `micro new function` commands. This implies the `--buildkit`
+flag.
+
+```bash
+go-micro new service --buildkit helloworld
+```
+
+### Kubernetes
+
+Micro can automatically generate kubernetes manifests for a service template.
+
+To create a new service with Kubernetes resources pass the `--kubernetes` flag to
+the `micro new service` or `micro new function` commands.
+
+```bash
+go-micro new service --kubernetes helloworld
+```
+
+### Kustomize - Kubernetes Resource Management
+
+Kustomize can be used to manage more complex Kubernetes manifests for various
+deployments, such as a development and production environment.
+
+To create a new service with Kubernetes resources organized in a Kustomize structure
+pass the `--kustomize` flag to the `micro new service` or `micro new function` 
+commands.
+
+```bash
+go-micro new service --kustomize helloworld
+```
+
+### gRPC Health Protocol - Kubernetes Probes
+
+Since Kubernetes [1.24](12), probes can make use of the [gRPC Health Protocol](13).
+This allows you to directly probe the go-micro service in a Kubernetes container
+if it implements the health protocol.
+
+By passing the `--health` flag the gRPC protocol will be implemented, and if 
+kubernetes manifests are generated through any of the flags, it will add probes
+to the deployment manifest.
+
+To use this feature, the `GRPCContainerProbe` feature gate needs to be enabled 
+inside your cluster. In version 1.24 this is enabled by default, in version 1.23
+you need to manually enable the feature gate.
+
+To create a new service with the gRPC health protocol implemented, pass the 
+`--health` flag to the `micro new service` or `micro new function` commands. This
+implies the `--grpc` flag.
+
+```bash
+go-micro new service --health helloworld
+```
+
+### Kubernetes Options
+
+#### Namespace
+
+Kubernetes manifests and Kustomize files set an explicit namespace by default.
+The default Kubernetes namespace is `default`. You can manually specify a differnt 
+namespace during service creation.
+
+```bash
+go-micro new service --kustomize --namespace=custom helloworld
+```
+
+#### Postgres Address
+
+If you create the service with the `--tern` flag, the default postgres address
+used is `postgres.database.svc`. To specify a different address use the 
+`--postgresaddress` flag
+
+```bash
+go-micro new service --kustomize --tern --postgresaddress="my.namespace.svc" helloworld
+```
+
+### Tilt - Kubernets Deployment
+
+Tilt can be used to set up a local Kubernetes deployment pipeline.
+
+To create a new service with a [Tiltfile][9] file, pass the `--tilt` flag to
+the `micro new service` or `micro new function` commands.
+
+This implies the `--kubernetes` flag.
+
+```bash
+go-micro new service --tilt helloworld
+```
+
+### Skaffold - Kubernetes Deployment
+
+Skaffold can be used to locally deploy a service.
 
 To create a new service with [Skaffold][9] files, pass the `--skaffold` flag to
 the `micro new service` or `micro new function` commands.
 
+This implies the `--kubernetes` flag.
+
 ```bash
 go-micro new service --skaffold helloworld
+```
+
+### Advanced
+
+Some patterns will often occur in more complex services. Such as the need to 
+gracefully shutdown go routines, and pass down a context to provide the cancelation  
+signal.
+
+To prevent you from having to rewrite them for every service, you can pass the 
+`--advanced` flag. This will generate a waitgroup, context, and define functions
+for `BeforeStart`, `BeforeStop` and `AfterStop`.
+
+```bash
+go-micro new service --advanced helloworld
+```
+
+### Complete
+
+With so many possible flags to create a service, the `--complete` flag will
+set the following flags to true:
+
+```bash
+go-micro new service --jaeger --health --grpc --sqlc --tern --buildkit --kustomize --tilt --advanced
 ```
 
 ## Running A Service
@@ -196,6 +419,22 @@ Skaffold pipeline using the `skaffold` command.
 ```bash
 skaffold dev
 ```
+
+### With Tilt
+
+When you've created your service using the `--tilt` flag, you may run the
+Tilt pipeline using the `tilt` command.
+
+```bash
+tilt up --stream
+```
+
+If you don't want to stream logs, but do want to exit on errors, you can run
+
+```bash
+tilt ci
+```
+
 
 ## Creating A Client
 
@@ -382,3 +621,7 @@ $ go-micro stream bidi helloworld Helloworld.BidiStream '{"stroke": 1}' '{"strok
 [7]: https://www.jaegertracing.io/
 [8]: https://github.com/jaegertracing/jaeger-client-go#environment-variables
 [9]: https://skaffold.dev/
+[10]: https://docs.tilt.dev/
+[11]: https://docs.docker.com/develop/develop-images/build_enhancements/
+[12]: https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
+[13]: https://github.com/grpc/grpc/blob/master/doc/health-checking.md

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ go-micro new service --tern helloworld
 
 ### sqlc - SQL Code Generation
 
-Sqlc can compile SQL queries into boilerplate Go code that allows you to easily
+[Sqlc](14) can compile SQL queries into boilerplate Go code that allows you to easily
 create and manage your database layer. Go-micro can set your service up for use
 with sqlc, and used Postgres as a default backend. Sqlc works well in combination 
 with [Tern](#tern---postgres-migrations). 
@@ -280,7 +280,7 @@ go-micro new service --kubernetes helloworld
 
 ### Kustomize - Kubernetes Resource Management
 
-Kustomize can be used to manage more complex Kubernetes manifests for various
+[Kustomize](15) can be used to manage more complex Kubernetes manifests for various
 deployments, such as a development and production environment.
 
 To create a new service with Kubernetes resources organized in a Kustomize structure
@@ -625,3 +625,5 @@ $ go-micro stream bidi helloworld Helloworld.BidiStream '{"stroke": 1}' '{"strok
 [11]: https://docs.docker.com/develop/develop-images/build_enhancements/
 [12]: https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
 [13]: https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+[14]: https://github.com/kyleconroy/sqlc
+[15]: https://kubectl.docs.kubernetes.io/references/kustomize/

--- a/generator/options.go
+++ b/generator/options.go
@@ -14,8 +14,30 @@ type Options struct {
 	Client bool
 	// Jaeger determines whether or not Jaeger integration is enabled.
 	Jaeger bool
-	// Jaeger determines whether or not Skaffold integration is enabled.
+	// Skaffold determines whether or not Skaffold integration is enabled.
 	Skaffold bool
+	// Tilt determines whether or not Tilt integration is enabled.
+	Tilt bool
+	// Health determines whether or not health proto service is enabled.
+	Health bool
+	// Kustomize determines whether or not Kustomize integration is enabled.
+	Kustomize bool
+	// Sqlc determines whether or not Sqlc integration is enabled.
+	Sqlc bool
+	// GRPC determines whether or not GRPC integration is enabled.
+	GRPC bool
+	// Buildkit determines whether or not Buildkit integration is enabled.
+	Buildkit bool
+	// Tern directory whether or not Tern integration is enabled.
+	Tern bool
+	// Advanced directory whether or not Advanced integration is enabled.
+	Advanced bool
+	// PrivateRepo
+	PrivateRepo bool
+	// Namespace sets the default namespace
+	Namespace string
+	// PostgresAddress sets the default postgres address
+	PostgresAddress string
 }
 
 // Option manipulates the Options passed.
@@ -60,5 +82,82 @@ func Jaeger(j bool) Option {
 func Skaffold(s bool) Option {
 	return func(o *Options) {
 		o.Skaffold = s
+	}
+}
+
+// Tilt sets whether or not Tilt integration is enabled.
+func Tilt(s bool) Option {
+	return func(o *Options) {
+		o.Tilt = s
+	}
+}
+
+// Health determines whether or not health proto service is enabled.
+func Health(s bool) Option {
+	return func(o *Options) {
+		o.Health = s
+	}
+}
+
+// Kustomize determines whether or not Kustomize integration is enabled.
+func Kustomize(s bool) Option {
+	return func(o *Options) {
+		o.Kustomize = s
+	}
+}
+
+// Sqlc determines whether or not Sqlc integration is enabled.
+func Sqlc(s bool) Option {
+	return func(o *Options) {
+		o.Sqlc = s
+	}
+}
+
+// GRPC determines whether or not GRPC integration is enabled.
+func GRPC(s bool) Option {
+	return func(o *Options) {
+		o.GRPC = s
+	}
+}
+
+// Buildkit determines whether or not Buildkit integration is enabled.
+func Buildkit(s bool) Option {
+	return func(o *Options) {
+		o.Buildkit = s
+	}
+}
+
+// Tern determines whether or not Tern integration is enabled.
+func Tern(s bool) Option {
+	return func(o *Options) {
+		o.Tern = s
+	}
+}
+
+// Advanced determines whether or not Advanced integration is enabled.
+func Advanced(s bool) Option {
+	return func(o *Options) {
+		o.Advanced = s
+	}
+}
+
+// PrivateRepo
+func PrivateRepo(s bool) Option {
+	return func(o *Options) {
+		o.PrivateRepo = s
+	}
+}
+
+// Namespace
+func Namespace(s string) Option {
+	return func(o *Options) {
+		o.Namespace = s
+	}
+}
+
+// PostgresAddress
+func PostgresAddress(s string) Option {
+	return func(o *Options) {
+		o.PostgresAddress = s
 	}
 }

--- a/generator/template/docker.go
+++ b/generator/template/docker.go
@@ -2,15 +2,38 @@ package template
 
 // Dockerfile is the Dockerfile template used for new projects.
 var Dockerfile = `FROM golang:alpine AS builder
+
+# Set Go env
 ENV CGO_ENABLED=0 GOOS=linux
 WORKDIR /go/src/{{.Service}}{{if .Client}}-client{{end}}
-RUN apk --update --no-cache add ca-certificates gcc libtool make musl-dev protoc
-COPY {{if not .Client}}Makefile {{end}}go.mod go.sum ./
-RUN {{if not .Client}}make init && {{end}}go mod download
-COPY . .
-RUN make {{if not .Client}}proto {{end}}tidy build
 
+# Install dependencies
+RUN apk --update --no-cache add ca-certificates gcc libtool make musl-dev protoc git{{if .PrivateRepo}} openssh-client{{end}}
+{{if ne .Vendor ""}}
+# Env config for private repo
+ENV GOPRIVATE="{{ gitorg .Vendor }}/*"
+RUN git config --global url."ssh://git@{{ gitorg .Vendor }}".insteadOf "https://{{ gitorg .Vendor }}" 
+{{else}}
+# Configure these values
+# ENV GOPRIVATE="github.com/<your private org>/*"
+# RUN git config --global url."ssh://git@github.com/<your private org>".insteadOf "https://github.com/<your private org>" 
+{{end}}
+{{- if .PrivateRepo}}
+# Authorize SSH Host
+RUN mkdir -p /root/.ssh && \
+	chmod 0700 /root/.ssh && \
+	ssh-keyscan github.com > /root/.ssh/known_hosts &&\
+	chmod 644 /root/.ssh/known_hosts && touch /root/.ssh/config
+{{end}}
+# Build Go binary
+COPY {{if not .Client}}Makefile {{end}}go.mod go.sum ./
+RUN {{if .PrivateRepo}}--mount=type=ssh {{end}}{{if .Buildkit}}--mount=type=cache,mode=0755,target=/go/pkg/mod {{end}}{{if not .Client}}make init && {{end}}go mod download 
+COPY . .
+RUN {{if .Buildkit}}--mount=type=cache,target=/root/.cache/go-build --mount=type=cache,mode=0755,target=/go/pkg/mod {{end}}make {{if not .Client}}proto {{end}}tidy build
+
+# Deployment container
 FROM scratch
+
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /go/src/{{.Service}}{{if .Client}}-client{{end}}/{{.Service}}{{if .Client}}-client{{end}} /{{.Service}}{{if .Client}}-client{{end}}
 ENTRYPOINT ["/{{.Service}}{{if .Client}}-client{{end}}"]
@@ -19,7 +42,7 @@ CMD []
 
 // DockerIgnore is the .dockerignore template used for new projects.
 var DockerIgnore = `.gitignore
-Dockerfile{{if .Skaffold}}
+Dockerfile{{if or .Skaffold .Kustomize}}
 resources/
 skaffold.yaml{{end}}
 `

--- a/generator/template/handler.go
+++ b/generator/template/handler.go
@@ -87,3 +87,26 @@ func (e *{{title .Service}}) BidiStream(ctx context.Context, stream pb.{{title .
 	}
 }
 `
+
+var HealthSRV = `package handler
+
+import (
+	"context"
+
+	pb "{{.Vendor}}{{.Service}}/proto"
+)
+
+type Health struct{}
+
+func (h *Health) Check(ctx context.Context, req *pb.HealthCheckRequest, rsp *pb.HealthCheckResponse) error {
+	rsp.Status = pb.HealthCheckResponse_SERVING
+	return nil
+}
+
+func (h *Health) Watch(ctx context.Context, req *pb.HealthCheckRequest, stream pb.Health_WatchStream) error {
+	stream.Send(&pb.HealthCheckResponse{
+		Status: pb.HealthCheckResponse_SERVING,
+	})
+	return nil
+}
+`

--- a/generator/template/kustomize.go
+++ b/generator/template/kustomize.go
@@ -1,0 +1,44 @@
+package template
+
+var KustomizationBase = `---
+
+namespace: {{ .Namespace }}
+
+resources:
+  - clusterrole.yaml
+  - deployment.yaml
+  - rolebinding.yaml
+
+configMapGenerator:
+  - name: {{tohyphen .Service}}{{if .Client}}-client{{end}}-env
+    envs:
+      - app.env
+{{- if .Tern}}
+  - name: {{tohyphen .Service}}{{if .Client}}-client{{end}}-migrations
+    files:
+      - ../../postgres/migrations/001_create_schema.sql
+{{end}}
+`
+var KustomizationDev = `---
+
+namespace: {{ .Namespace }}
+
+resources:
+ - ../base/
+`
+
+var KustomizationProd = `---
+
+namespace: {{ .Namespace }}
+
+resources:
+ - ../base/
+`
+
+var AppEnv = `MICRO_REGISTRY=kubernetes
+{{- if .Tern}}
+PGHOST={{ .PostgresAddress }}
+PGUSER={{lowerhyphen .Service}}{{if .Client}}_client{{end}}
+PGDATABASE={{lowerhyphen .Service}}{{if .Client}}_client{{end}}
+{{end}}
+`

--- a/generator/template/main.go
+++ b/generator/template/main.go
@@ -11,6 +11,9 @@ import (
 
 	"go-micro.dev/v4"
 	log "go-micro.dev/v4/logger"
+{{if .GRPC}}
+	"github.com/asim/go-micro/plugins/client/grpc/v4"
+{{end}}
 )
 
 var (
@@ -20,7 +23,13 @@ var (
 
 func main() {
 	// Create service
+	{{if .GRPC}}
+	srv := micro.NewService(
+		micro.Client(grpc.NewClient()),
+	)
+	{{else}}
 	srv := micro.NewService()
+	{{end}}
 	srv.Init()
 
 	// Create client
@@ -95,14 +104,26 @@ func main() {
 var MainSRV = `package main
 
 import (
+{{- if .Advanced}}
+	"context"
+	"sync"
+{{- end}}
+
 	"{{.Vendor}}{{.Service}}/handler"
 	pb "{{.Vendor}}{{.Service}}/proto"
 
 {{if .Jaeger}}	ot "github.com/asim/go-micro/plugins/wrapper/trace/opentracing/v4"
 {{end}}	"go-micro.dev/v4"
 	log "go-micro.dev/v4/logger"{{if .Jaeger}}
+{{- if .Advanced}}
+	"go-micro.dev/v4/server"
+{{- end}}
 
-	"go-micro.dev/v4/cmd/micro/debug/trace/jaeger"{{end}}
+	"github.com/go-micro/cli/debug/trace/jaeger"{{end}}
+{{if .GRPC}}
+	grpcc "github.com/asim/go-micro/plugins/client/grpc/v4"
+	"github.com/asim/go-micro/plugins/server/grpc/v4"
+{{- end}}
 )
 
 var (
@@ -121,21 +142,53 @@ func main() {
 		log.Fatal(err)
 	}
 	defer closer.Close()
+{{ if .Advanced }}
+	wg := sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.Background())
+{{- end }}
 
 {{end}}	// Create service
 	srv := micro.NewService(
+{{- if .GRPC}}
+		micro.Server(grpc.NewServer()),
+		micro.Client(grpcc.NewClient()),
+{{- end}}
 		micro.Name(service),
 		micro.Version(version),
+{{- if .Advanced}}
+		micro.BeforeStart(func() error {
+			log.Infof("Starting service %s", service)
+			return nil
+		}),
+		micro.BeforeStop(func() error {
+			log.Infof("Shutting down service %s", service)
+			cancel()
+			return nil
+		}),
+		micro.AfterStop(func() error {
+			wg.Wait()
+			return nil
+		}),
+{{- end}}
 {{if .Jaeger}}		micro.WrapCall(ot.NewCallWrapper(tracer)),
 		micro.WrapClient(ot.NewClientWrapper(tracer)),
 		micro.WrapHandler(ot.NewHandlerWrapper(tracer)),
 		micro.WrapSubscriber(ot.NewSubscriberWrapper(tracer)),
 {{end}}	)
 	srv.Init()
+{{- if .Advanced}}
+	srv.Server().Init(
+		server.Wait(&wg),
+	)
+
+	ctx = server.NewContext(ctx, srv.Server())
+{{- end}}
 
 	// Register handler
 	pb.Register{{title .Service}}Handler(srv.Server(), new(handler.{{title .Service}}))
-
+{{- if .Health}}
+	pb.RegisterHealthHandler(srv.Server(), new(handler.Health))
+{{end}}
 	// Run service
 	if err := srv.Run(); err != nil {
 		log.Fatal(err)

--- a/generator/template/makefile.go
+++ b/generator/template/makefile.go
@@ -8,6 +8,12 @@ init:
 	@go get -u google.golang.org/protobuf/proto
 	@go install github.com/golang/protobuf/protoc-gen-go@latest
 	@go install github.com/asim/go-micro/cmd/protoc-gen-micro/v4@latest
+	{{- if .Tern}}
+	@go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
+	{{- end}}
+	{{- if .Sqlc}}
+	@go install github.com/jackc/tern@latest
+	{{- end}}
 
 .PHONY: proto
 proto:
@@ -31,5 +37,12 @@ test:
 
 .PHONY: docker
 docker:
-	@docker build -t {{.Service}}{{if .Client}}-client{{end}}:latest .
+	@{{if .Buildkit}}DOCKER_BUILDKIT=1 {{end}}docker build -t {{.Service}}{{if .Client}}-client{{end}}:latest {{if .PrivateRepo}}--ssh=default {{end}}.
+
+{{- if .Sqlc}}
+
+.PHONY: sqlc
+sqlc:
+	@sqlc generate -f ./postgres/sqlc.yaml
+{{- end -}}
 `

--- a/generator/template/module.go
+++ b/generator/template/module.go
@@ -3,15 +3,16 @@ package template
 // Module is the go.mod template used for new projects.
 var Module = `module {{.Vendor}}{{.Service}}{{if .Client}}-client{{end}}
 
-go 1.16
+go 1.18
 
 require (
 	go-micro.dev/v4 v4.1.0
 )
 
+// Uncomment if you use etcd
 // This can be removed once etcd becomes go gettable, version 3.4 and 3.5 is not,
 // see https://github.com/etcd-io/etcd/issues/11154 and https://github.com/etcd-io/etcd/issues/11931.
-replace google.golang.org/grpc => google.golang.org/grpc v1.26.0{{if .Vendor}}{{if not .Skaffold}}
+// replace google.golang.org/grpc => google.golang.org/grpc v1.26.0
 
-replace {{.Vendor}}{{lower .Service}} => ../{{lower .Service}}{{end}}{{end}}
+replace {{.Vendor}}{{lower .Service}} => ./
 `

--- a/generator/template/proto.go
+++ b/generator/template/proto.go
@@ -65,4 +65,25 @@ message BidiStreamRequest {
 message BidiStreamResponse {
 	int64 stroke = 1;
 }
+
+{{if .Health}}
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse) {}
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse) {}
+}
+
+message HealthCheckRequest { 
+	string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+  ServingStatus status = 1;
+}
+{{end}}
 `

--- a/generator/template/skaffold.go
+++ b/generator/template/skaffold.go
@@ -11,7 +11,17 @@ build:
   artifacts:
   - image: {{.Service}}{{if .Client}}-client{{end}}
 deploy:
+{{- if .Kustomize}}
+  kustomize:
+    paths:
+      - ./resources/dev/
+{{- if .Tern}}
+    buildArgs:
+      - load-restrictor LoadRestrictionsNone
+{{end}}
+{{- else}}
   kubectl:
     manifests:
-    - resources/*.yaml
+      - resources/*.yaml
+{{end}}
 `

--- a/generator/template/sqlc.go
+++ b/generator/template/sqlc.go
@@ -1,0 +1,57 @@
+package template
+
+var Sqlc = `---
+
+version: 1
+packages:
+  - path: "sqlc"
+    name: "sqlc"
+    engine: "postgresql"
+    sql_package: "pgx/v4"
+    schema: "./migrations/"
+    queries: "./queries/"
+`
+
+var Postgres = `package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+
+	"{{.Vendor}}{{.Service}}/postgres/sqlc"
+)
+
+type DB struct {
+	conn *sqlc.Queries
+}
+
+func NewDB(connString string) (*DB, func(), error) {
+	// Do not use main context since some business logic closing down might still
+	//  need to commit to database. Be sure to defer pool.Close in main.
+	pool, err := pgxpool.Connect(context.Background(), connString)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to create pgx connection pool")
+	}
+
+	db := DB{
+		conn: sqlc.New(pool),
+	}
+	return &db, pool.Close, nil
+}
+
+// QueryExample is a example of how you can use sqlc to create your database layer
+func (db *DB) QueryExample() (int, error) {
+	i, err := db.conn.SampleQuery(context.Background())
+	if err != nil {
+		return int(i), errors.Wrap(err, "Failed to query SampleQuery")
+	}
+	return int(i), nil
+}
+`
+
+var QueryExample = `-- name: SampleQuery :one
+SELECT
+    1::int;
+`

--- a/generator/template/tern.go
+++ b/generator/template/tern.go
@@ -1,0 +1,9 @@
+package template
+
+var TernSql = `-- Write your migrate up statements here
+
+---- create above / drop below ----
+
+-- Write your migrate down statements here. If this migration is irreversible
+-- Then delete the separator line above.
+`

--- a/generator/template/tilt.go
+++ b/generator/template/tilt.go
@@ -1,0 +1,37 @@
+package template
+
+var Tiltfile = `{{if .PrivateRepo -}}
+# Start SSH Agent
+if os.getenv('SSH_AUTH_SOCK', '') == "":
+    git_key = os.getenv('GIT_SSH_KEY', '')
+    local('eval $(ssh-agent) && ssh-add {}'.format(git_key))
+
+{{end -}}
+# Build Docker image
+docker_build('{{.Service}}{{if .Client}}-client{{end}}',
+             context='.',
+             dockerfile='./Dockerfile',
+{{- if .PrivateRepo}}
+             ssh='default',
+{{- end}}
+)
+
+# Config
+{{- if .Kustomize}}KUSTOMIZE_DIR="./resources/dev/"
+
+{{- if .Tern}}# LoadRestrictor option is passed as migrations need to be accessed outside of base directory
+# See: https://github.com/kubernetes-sigs/kustomize/issues/865
+manifests = local("kustomize build --load-restrictor LoadRestrictionsNone {dir}".format(dir=KUSTOMIZE_DIR), quiet=True)
+{{- else}}
+manifests = kustomize(KUSTOMIZE_DIR)
+{{- end}}
+{{- else}}
+KUBERNETS_DIR="./resources"
+manifests = listdir(KUBERNETES_DIR)
+{{- end}}
+
+# Apply Kubernetes manifests
+# Allow duplcates is marked true for when you import multiple go-micro Tiltfiles
+#  into a single Tiltfile it will mark the clusterrole as duplicate.
+k8s_yaml(manifests, allow_duplicates=True)
+`


### PR DESCRIPTION
After writing a few services with go-micro I've started to create patterns for myself, and found myself writing the same boilerplate code and structure after creating a new service. Therefore I decided to amend the CLI to add these options, so I can create a fitting service template for my workflow. Since it's so personal I'm not sure how much of it is relevant to add to the CLI as a whole, and I'm definitely open to improvements, but since I've written it anyway I figured I'd create a PR. 

I have explained all the added options in the `README.md``. 

I'm now able to create a perfect template for myself with 
```bash
go-micro new service --complete --privaterepo --namespace=custom --postgresaddress="timescaledb.database.svc" github.com/org/repo/service
```