### PR TITLE
Fix #9, fix #11, fix #12

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -55,9 +55,14 @@ func Run(ctx *cli.Context) error {
 		return err
 	}
 
+	tmpSrc := source.RuntimeSource()
+	if os.Getenv("GOOS") == "windows" {
+		tmpPath = strings.Replace(source.RuntimeSource(), ":", "", 1)
+	}
+	
 	svc := &runtime.Service{
 		Name:     source.RuntimeName(),
-		Source:   source.RuntimeSource(),
+		Source:   tmpSrc,
 		Version:  source.Ref,
 		Metadata: make(map[string]string),
 	}


### PR DESCRIPTION
The problem is temporary folder structure creation — two colons are not allowed in a windows path.